### PR TITLE
Remove SharedArray dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,6 @@ uuid = "b7351bd1-99d9-5c5d-8786-f205a815c4d7"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-SharedArrays = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [extras]

--- a/src/NonNegLeastSquares.jl
+++ b/src/NonNegLeastSquares.jl
@@ -5,7 +5,6 @@ module NonNegLeastSquares
 using Compat
 using Distributed
 using LinearAlgebra
-using SharedArrays
 import SparseArrays
 
 export nonneg_lsq

--- a/src/fnnls.jl
+++ b/src/fnnls.jl
@@ -96,11 +96,9 @@ function fnnls(A,
     end
 
     if use_parallel && nprocs()>1
-        X = SharedArray{eltype(B)}(n,k)
-        @sync @distributed for i = 1:k
-            X[:,i] = fnnls(AtA, AtB[:,i]; kwargs...)
+        X = @distributed (hcat) for i=1:k
+            fnnls(AtA, AtB[:,i]; kwargs...)
         end
-        X = convert(Array,X)
     else
         X = Array{eltype(B)}(undef,n,k)
         for i = 1:k

--- a/src/pivot.jl
+++ b/src/pivot.jl
@@ -91,11 +91,9 @@ function pivot(A,
 
     # compute result for each column
     if use_parallel && nprocs()>1
-        X = SharedArray{T}(n,k)
-        @sync @distributed for i = 1:k
-            X[:,i] = pivot(A, B[:,i]; kwargs...)
+        X = @distributed (hcat) for i = 1:k
+            pivot(A, B[:,i]; kwargs...)
         end
-        X = convert(Array,X)
     else
         X = Array{T}(undef,n,k)
         for i = 1:k

--- a/src/pivot_cache.jl
+++ b/src/pivot_cache.jl
@@ -111,11 +111,9 @@ function pivot_cache(A,
 
     # compute result for each column
     if use_parallel && nprocs()>1
-        X = SharedArray{T}(n,k)
-        @sync @distributed for i = 1:k
-            X[:,i] = pivot_cache(AtA, AtB[:,i]; kwargs...)
+        X = @distributed (hcat) for i = 1:k
+            pivot_cache(AtA, AtB[:,i]; kwargs...)
         end
-        X = convert(Array,X)
     else
         X = Array{T}(undef,n,k)
         for i = 1:k


### PR DESCRIPTION
I was having an issue with the SharedArray parallism when working with distributed processes. This PR removes SharedArrays and just uses `@distributed` with an `hcat` reduction operator.