### PR TITLE
Finish transition to Project.toml (#18)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,15 @@
 name = "NonNegLeastSquares"
 uuid = "b7351bd1-99d9-5c5d-8786-f205a815c4d7"
+version = "0.1.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[compat]
+julia = "1.0"
 
 [extras]
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.5
-Compat 0.16


### PR DESCRIPTION
In preparation for resolving #18 and #12. Fixes up the Project.toml with a version number, drops the Require, and hopefully is set for registration.

I set the Julia compatibility to 1.0, I'm not sure of the earliest version this package works at.