### PR TITLE
Fix tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test
-using LinearAlgebra: norm
+using LinearAlgebra: norm, I
 using NonNegLeastSquares: nonneg_lsq
 using SparseArrays
 

--- a/test/sparse_test.jl
+++ b/test/sparse_test.jl
@@ -1,6 +1,6 @@
 # test simple solving
 Random.seed!(1234)
-sA = sprand(20, 20, 0.1)
+sA = sprand(20, 20, 0.1) + 0.001 * I
 b = rand(20)
 A = collect(sA)
 


### PR DESCRIPTION
The random seed is not stable across Julia versions, so the random
matrices are not consistent. On Julia 1.10 (and some other versions too),
the random matrix in `sparse_test` is not full rank, so the test fails.
This adds a small diagonal to ensure it has full rank.