### PR TITLE
Remove redundant computations for y in pivot methods

### DIFF
--- a/src/pivot.jl
+++ b/src/pivot.jl
@@ -34,8 +34,6 @@ function pivot(A,
     #    we want X[~P]== 0, Y[~P] >= 0
     P = BitArray(false for _ in 1:q)
 
-    y[(!).(P)] =  A[:,(!).(P)]' * (A[:,P]*x[P] - b)
-
     # identify indices of infeasible variables
     V = @__dot__ (P & (x < -tol)) | (!P & (y < -tol))
     nV = sum(V)

--- a/src/pivot_cache.jl
+++ b/src/pivot_cache.jl
@@ -37,8 +37,6 @@ function pivot_cache(
     #    we want X[~P]== 0, Y[~P] >= 0
     P = falses(q)
 
-    y[(!).(P)] = AtA[(!).(P),P] * x[P] - Atb[(!).(P)]
-
     # identify indices of infeasible variables
     V = @. (P & (x < -tol)) | (!P & (y < -tol))
     nV = sum(V)


### PR DESCRIPTION
If I'm reading this right, this doesn't do anything